### PR TITLE
Added edge centrality to betweenness centrality

### DIFF
--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -3332,12 +3332,12 @@
             {
               "name": "eles.betweennessCentrality",
               "pureAliases": ["eles.bc"],
-              "descr": "Considering only the elements in the calling collection, calculate the [betweenness centrality](https://en.wikipedia.org/wiki/Betweenness_centrality) of the nodes.",
+              "descr": "Considering only the elements in the calling collection, calculate the [betweenness centrality](https://en.wikipedia.org/wiki/Betweenness_centrality) of the nodes and edges.",
               "formats": [
                 {
                   "args": [
                     { "name": "options", "fields": [
-                      { "name": "weight: function(edge)", "descr": "A function that returns the positive weight for the edge.  The weight indicates the importance of the edge, with a high value representing high importance.", "optional": true },
+                      { "name": "weight: function(edge)", "descr": "A function that returns the positive weight for the edge.  The weight indicates the importance of the edge, with a low value representing high importance.", "optional": true },
                       { "name": "directed", "descr": "A boolean indicating whether the algorithm operates on edges in a directed manner from source to target (`true`) or whether the algorithm operates in an undirected manner (`false`, default).", "optional": true }
                     ] }
                   ]

--- a/documentation/md/collection/betweennessCentrality.md
+++ b/documentation/md/collection/betweennessCentrality.md
@@ -8,8 +8,15 @@ This function returns an object of the form:
   betweenness: function( node ){ /* impl */ },
 
   /* returns the normalised betweenness centrality of the specified node */
-  betweennessNormalized: function( node ){ /* impl */ }
+  betweennessNormalized: function( node ){ /* impl */ },
   /* alias : betweennessNormalised() */
+
+  /* returns the betweenness centrality of the specified edge */
+  betweennessEdge: function( edge ){ /* impl */ },
+
+  /* returns the normalised betweenness centrality of the specified edge */
+  betweennessEdgeNormalized: function( edge ){ /* impl */ },
+  /* alias : betweennessEdgeNormalised() */
 }
 ```
 

--- a/test/collection-algorithms.js
+++ b/test/collection-algorithms.js
@@ -981,6 +981,80 @@ describe('Algorithms', function(){
     expect( res.betweenness(e) ).to.equal(4);
   });
 
+  it("eles.betweennessCentrality() weighted undirected edges", function () {
+    /*
+    4                 4
+    ┌─────────d────────┐
+    │         │        │
+    │         │1       │
+    │    1    │        │
+    a ─────── c────────b
+    │         │   1    │
+    │        1│        │
+    │         │        │
+    └──────── d ───────┘
+    4                 4
+    */
+    const cy2 = cytoscape({
+      elements: {
+        nodes: [
+          { data: { id: "a" } },
+          { data: { id: "b" } },
+          { data: { id: "c" } },
+          { data: { id: "d" } },
+          { data: { id: "e" } },
+        ],
+
+        edges: [
+          { data: { id: "ae", weight: 4, source: "a", target: "e" } },
+          { data: { id: "ad", weight: 4, source: "a", target: "d" } },
+          { data: { id: "ac", weight: 1, source: "a", target: "c" } },
+          { data: { id: "cd", weight: 1, source: "c", target: "d" } },
+          { data: { id: "ce", weight: 1, source: "c", target: "e" } },
+          { data: { id: "cb", weight: 1, source: "c", target: "b" } },
+          { data: { id: "db", weight: 4, source: "d", target: "b" } },
+          { data: { id: "eb", weight: 4, source: "e", target: "b" } },
+        ],
+      },
+      ready: function () {
+        a = this.$("#a");
+        b = this.$("#b");
+        c = this.$("#c");
+        d = this.$("#d");
+        e = this.$("#e");
+
+        ae = this.$("#ae");
+        ad = this.$("#ad");
+        ac = this.$("#ac");
+        cd = this.$("#cd");
+        ce = this.$("#ce");
+        cb = this.$("#cb");
+        db = this.$("#db");
+        eb = this.$("#eb");
+      },
+    });
+    var res = cy2.elements().betweennessCentrality({
+      weight: function (ele) {
+        return ele.data("weight");
+      },
+    });
+
+    expect(res.betweenness(a)).to.equal(0);
+    expect(res.betweenness(b)).to.equal(0);
+    expect(res.betweenness(c)).to.equal(12);
+    expect(res.betweenness(d)).to.equal(0);
+    expect(res.betweenness(e)).to.equal(0);
+
+    expect(res.betweennessEdge(ae)).to.equal(0);
+    expect(res.betweennessEdge(ad)).to.equal(0);
+    expect(res.betweennessEdge(ac)).to.equal(4);
+    expect(res.betweennessEdge(cd)).to.equal(4);
+    expect(res.betweennessEdge(ce)).to.equal(4);
+    expect(res.betweennessEdge(cb)).to.equal(4);
+    expect(res.betweennessEdge(db)).to.equal(0);
+    expect(res.betweennessEdge(eb)).to.equal(0);
+  });
+
   it('eles.betweennessCentrality() weighted directed', function(){
     var res = cy.elements().betweennessCentrality({
       weight: function( ele ){


### PR DESCRIPTION
**Issue type**
- Feature request

**Description of new feature**

Adds the edge betweenness centrality to the betweenness centrality algorithm. Implemented according to the paper referenced in the code.


**Motivation for new feature**

I needed to calculate edge betweenness centrality for a use-case. Edge centrality comes basically for free when doing node betweenness centrality.


It might be helpful for others as well.